### PR TITLE
 Fix issue 1219

### DIFF
--- a/modules/items/item-sheet-ffg.js
+++ b/modules/items/item-sheet-ffg.js
@@ -877,7 +877,7 @@ export class ItemSheetFFG extends ItemSheet {
           }
 
           if (foundItem && this.object.type !== "itemattachment") {
-            foundItem.system.rank += itemObject.system.rank;
+            foundItem.system.rank = (parseInt(foundItem.system.rank) + parseInt(itemObject.system.rank)).toString();
           } else {
             items.push(itemObject);
           }


### PR DESCRIPTION
Modifier ranks were being appended as strings. 1+1 would equal 11. Now existing rank and modifier rank are parsed to ints, summed, and made strings again for the item sheet. Remade rank into strings to try not to break other functionality.